### PR TITLE
Bugfix, the moment locale filename is lowercase

### DIFF
--- a/meteor/client.js
+++ b/meteor/client.js
@@ -34,7 +34,7 @@ if (Package['tap:i18n']) {
   Meteor.startup(function() {
     Tracker.autorun(function() {
       var language = TAPi18n.getLanguage();
-      var localePath = 'packages/mquandalle_moment/locale/' + language + '.js';
+      var localePath = 'packages/mquandalle_moment/locale/' + language.toLowerCase() + '.js';
       if (alreadyLoadedLanguages.indexOf(language) === -1) {
         $.ajax({
           url: Meteor.absoluteUrl(localePath),


### PR DESCRIPTION
For example, TAPi18n.getLanguage() return "zh-CN" for Chinese, while the moment locale filename is zh-cn.js, so need change to lowercase.
